### PR TITLE
change vegetable oil to canola oil for health reasons

### DIFF
--- a/cake-recipe.txt
+++ b/cake-recipe.txt
@@ -7,7 +7,7 @@ Ingredients:
  - 1 teaspoon salt
  - 2 eggs
  - 1 cup milk
- - 1/2 cup vegetable oil
+ - 1/2 cup canols oil
  - 2 teaspoons vanilla extract
  - 1 cup boiling water
 

--- a/cake-recipe.txt
+++ b/cake-recipe.txt
@@ -7,7 +7,7 @@ Ingredients:
  - 1 teaspoon salt
  - 2 eggs
  - 1 cup milk
- - 1/2 cup canols oil
+ - 1/2 cup canola oil
  - 2 teaspoons vanilla extract
  - 1 cup boiling water
 


### PR DESCRIPTION
Canola oil is purported to be more healthy than regular vegetable oil, and I think it would fit well in this recipe.